### PR TITLE
Improved typing and uses of classes

### DIFF
--- a/NewsUK/ruleset.xml
+++ b/NewsUK/ruleset.xml
@@ -62,6 +62,14 @@
 
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
 
+	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition" />
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		 <properties>
+			<property name="searchAnnotations" value="true" />
+		</properties>
+	</rule>
+
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>
 	<file>.</file>


### PR DESCRIPTION
Implement the [SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition](https://github.com/slevomat/coding-standard/blob/master/doc/type-hints.md#slevomatcodingstandardtypehintsnulltypehintonlastposition-) and [SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue](https://github.com/slevomat/coding-standard/blob/master/doc/type-hints.md#slevomatcodingstandardtypehintsnullabletypefornulldefaultvalue-) rules. These rules improve how nullable types are handled. 
These rules convert
 `?int $image_id` to `?int $image_id = null` and
  `int $image_id = null` to `?int $image_id = null`


The [SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly](https://github.com/slevomat/coding-standard/blob/master/doc/namespaces.md#slevomatcodingstandardnamespacesreferenceusednamesonly-) rules, force classes to be imported, so references like this `new \Foo\Boo();` to `use \Foo\Boo; new Boo();`


