### PR TITLE
feat: Add NewsPress ruleset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,14 @@ jobs:
                   name: Composer validate
                   command: composer validate --strict
             - run:
-                  name: Check if NewsUK PHPCS standard is installed
+                  name: Check if NewsUK and NewsPress PHPCS standards are installed
                   command: |
-                    vendor/bin/phpcs -i
-                    if vendor/bin/phpcs -i | grep -q "NewsUK"; then
-                      echo "NewsUK PHPCS standard is installed successfully."
+                    phpcsStandards=$(vendor/bin/phpcs -i)
+                    echo phpcsStandards
+                    if echo $phpcsStandards | grep -q "NewsUK" && echo $phpcsStandards | grep -q "NewsPress"; then
+                      echo "NewsUK and NewsPress PHPCS standard are installed successfully."
                     else
-                      echo "Error: NewsUK PHPCS standard is not installed."
+                      echo "Error: NewsUK and NewsPress PHPCS standard are not installed."
                       exit 1
                     fi
             - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                   name: Check if NewsUK and NewsPress PHPCS standards are installed
                   command: |
                     phpcsStandards=$(vendor/bin/phpcs -i)
-                    echo phpcsStandards
+                    echo $phpcsStandards
                     if echo $phpcsStandards | grep -q "NewsUK" && echo $phpcsStandards | grep -q "NewsPress"; then
                       echo "NewsUK and NewsPress PHPCS standard are installed successfully."
                     else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
                     phpcsStandards=$(vendor/bin/phpcs -i)
                     echo $phpcsStandards
                     if echo $phpcsStandards | grep -q "NewsUK" && echo $phpcsStandards | grep -q "NewsPress"; then
-                      echo "NewsUK and NewsPress PHPCS standard are installed successfully."
+                      echo "NewsUK and NewsPress PHPCS standards are installed successfully."
                     else
-                      echo "Error: NewsUK and NewsPress PHPCS standard are not installed."
+                      echo "Error: NewsUK and NewsPress PHPCS standards are not installed."
                       exit 1
                     fi
             - persist_to_workspace:

--- a/NewsPress/ruleset.xml
+++ b/NewsPress/ruleset.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<ruleset name="NewsPress">
+	<config name="minimum_supported_wp_version" value="6.2" />
+	<config name="testVersion" value="8.2-"/>
+
+	<rule ref="PHPCompatibilityWP" />
+
+	<rule ref="WordPress-Docs">
+		<severity>5</severity>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress-Extra">
+		<severity>5</severity>
+	</rule>
+	<rule ref="WordPress-Core">
+		<severity>5</severity>
+	</rule>
+	<rule ref="WordPress-VIP-Go">
+		<severity>5</severity>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="newspress"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Disable some sniffs that conflict with PSR-4. -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>includes/*</exclude-pattern>
+		<exclude-pattern>inc/*</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.WP.AlternativeFunctions.json_encode_json_encode">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>includes/*</exclude-pattern>
+		<exclude-pattern>inc/*</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Universal.Operators.DisallowShortTernary.Found">
+		<severity>0</severity>
+	</rule>
+
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax.Found">
+		<severity>0</severity>
+	</rule>
+
+	<rule ref="WordPress.PHP.YodaConditions.NotYoda">
+		<severity>0</severity>
+	</rule>
+
+	<rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
+		<severity>0</severity>
+	</rule>
+
+	<rule ref="PSR2.Namespaces.UseDeclaration">
+		<exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations" />
+	</rule>
+	<rule ref="PSR2R.Namespaces.UnusedUseStatement" />
+
+	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition" />
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		<properties>
+			<property name="searchAnnotations" value="true" />
+		</properties>
+	</rule>
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="sp"/>
+
+	<arg name="colors"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20" />
+
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/cypress/*</exclude-pattern>
+	<exclude-pattern>/build/*</exclude-pattern>
+	<exclude-pattern>/tests/wp-tests-config.php</exclude-pattern>
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require --dev newsuk/nuk-wp-phpcs-config
 ```
 
 ## Using the ruleset
-Create a `phpcs.xml.dist` file in your project and add the following:
+Create a `phpcs.xml.dist` file in your project and add the following to use `NewsUK` ruleset:
 
 ```xml
 <?xml version="1.0"?>
@@ -23,7 +23,7 @@ Create a `phpcs.xml.dist` file in your project and add the following:
 	<rule ref="NewsUK"/>
 </ruleset>
 ```
-💡 *It is recommended to use the `NewsUK` ruleset as it is without customising or overriding rules unless necessary.*
+💡 *It is recommended to use the `NewsUK` or `NewsPress` ruleset as it is without customising or overriding rules unless necessary.*
 
 ## Override or add custom rules
 You can also override or add custom rules to the config as follows.


### PR DESCRIPTION
- Adds new ruleset for `NewsPress` by mimicing newsuk rules. Further ruleset changes should consider applying the new rules to both ruleset if it's useful for everyone.
- This will help NewsPress team to use this as a global config without needing to add custom configs just to add text domain.