### PR TITLE
Update PSR2R-sniffer version and remove UnusedUseStatement rule

### DIFF
--- a/NewsPress/ruleset.xml
+++ b/NewsPress/ruleset.xml
@@ -67,7 +67,6 @@
 	<rule ref="PSR2.Namespaces.UseDeclaration">
 		<exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations" />
 	</rule>
-	<rule ref="PSR2R.Namespaces.UnusedUseStatement" />
 
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/NewsUK/ruleset.xml
+++ b/NewsUK/ruleset.xml
@@ -67,7 +67,6 @@
 	<rule ref="PSR2.Namespaces.UseDeclaration">
 		<exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations" />
 	</rule>
-	<rule ref="PSR2R.Namespaces.UnusedUseStatement" />
 
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "automattic/vipwpcs": "^3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "ergebnis/composer-normalize": "^2.42",
-        "fig-r/psr2r-sniffer": "^2.0",
+        "fig-r/psr2r-sniffer": "^2.1.2",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "slevomat/coding-standard": "^8.14",
         "wp-coding-standards/wpcs": "^3.1"


### PR DESCRIPTION
Upgraded `fig-r/psr2r-sniffer` to version 2.1.2 in `composer.json`. Removed the `PSR2R.Namespaces.UnusedUseStatement` rule from both `NewsUK/ruleset.xml` and `NewsPress/ruleset.xml` to align with updated coding standards. Without this fix all PHPCS lint jobs that uses this library will fail.

This rule was removed recently. More details [here](https://github.com/php-fig-rectified/psr2r-sniffer/releases/tag/2.1.2) and the [commit](https://github.com/php-fig-rectified/psr2r-sniffer/commit/a63fb4d23414ed3800d7819103b4049134b30d8c).

